### PR TITLE
RCPs and params update automatically

### DIFF
--- a/inst/shinyApp/server.r
+++ b/inst/shinyApp/server.r
@@ -233,10 +233,10 @@ server <- function(input, output, session)
   # observeEvent(input$set_Params, setParameters(), ignoreInit = TRUE)
   observeEvent(input$input_ScenarioFile, loadScenario(), ignoreInit = TRUE)
   observeEvent(input$reset_Params, resetParams(), ignoreInit = TRUE)
-  observeEvent(input$input_RCP_2.6, setRCP("RCP-2.6"), ignoreInit = TRUE)
-  observeEvent(input$input_RCP_4.5, setRCP("RCP-4.5"), ignoreInit = FALSE)
-  observeEvent(input$input_RCP_6.0, setRCP("RCP-6.0"), ignoreInit = TRUE)
-  observeEvent(input$input_RCP_8.5, setRCP("RCP-8.5"), ignoreInit = TRUE)
+  observeEvent(input$input_RCP_2.6, {setRCP("RCP-2.6"); setParameters(); loadGraph()}, ignoreInit = TRUE)
+  observeEvent(input$input_RCP_4.5, {setRCP("RCP-4.5"); setParameters(); loadGraph()}, ignoreInit = FALSE)
+  observeEvent(input$input_RCP_6.0, {setRCP("RCP-6.0"); setParameters(); loadGraph()}, ignoreInit = TRUE)
+  observeEvent(input$input_RCP_8.5, {setRCP("RCP-8.5"); setParameters(); loadGraph()}, ignoreInit = TRUE)
   observeEvent(input$input_enableCustom, setRCP("Custom"), ignoreInit = TRUE)
   observeEvent(input$input_load_custom, loadCustomScenario(), ignoreInit = TRUE)
   observeEvent(input$input_load_emissions, loadCustomEmissions(), ignoreInit = TRUE)
@@ -249,19 +249,29 @@ server <- function(input, output, session)
   observeEvent(input$mapCore, updateIndex(), ignoreInit = TRUE)
   observeEvent(input$saveMap, saveMap(), ignoreInit = TRUE)
 
+  # Observe param changes
+  #observeEvent(input$input_pco2, loadGraph(), ignoreInit = FALSE)
+  observeEvent(input$input_q10, {setParameters(); loadGraph()}, ignoreInit = FALSE)
+  observeEvent(input$input_volc, {setParameters(); loadGraph()}, ignoreInit = FALSE)
+  observeEvent(input$input_aero, {setParameters(); loadGraph()}, ignoreInit = FALSE)
+  observeEvent(input$input_beta, {setParameters(); loadGraph()}, ignoreInit = FALSE)
+  observeEvent(input$input_diff, {setParameters(); loadGraph()}, ignoreInit = FALSE)
+  observeEvent(input$input_ecs, {setParameters(); loadGraph()}, ignoreInit = FALSE)
 
-function()
+
+#function()
 
   # This is a group Observer block for all of the params fields because they all respond the same way
-  observe({
-    input$input_pco2
-    input$input_q10
-    input$input_volc
-    input$input_aero
-    input$input_beta
-    input$input_diff
-    input$input_ecs
-  })
+  #observe({
+    #input$input_pco2
+    #input$input_q10
+    #input$input_volc
+    #input$input_aero
+    #input$input_beta
+    #input$input_diff
+    #input$input_ecs
+  #})
+  # ^^ replaced by observeEvent functions above
 
 #----- End observer function setup
 

--- a/inst/shinyApp/ui.r
+++ b/inst/shinyApp/ui.r
@@ -110,13 +110,13 @@ fluidPage(theme = shinythemes::shinytheme("readable"),
                                   ),
                                   fluidRow(
                                       column(12,
-                                             sliderInput("input_aero", "Aerosol forcing scaling factor", min = 0, max = 1, value = 1, width = "90%"),
-                                             sliderInput("input_beta", "CO2 fertilization factor", min = 0, max = 4, value = 0.36, step = 0.01, width = "90%"),
-                                             sliderInput("input_diff", "Ocean heat diffusivity", min = 0, max = 5, value = 2.3, step = 0.1, post = " cm2/s", width = "90%"),
+                                             sliderInput("input_aero", "Aerosol forcing scaling factor", min = 0.01, max = 1, value = 1, width = "90%"),
+                                             sliderInput("input_beta", "CO2 fertilization factor", min = 0.01, max = 4, value = 0.36, step = 0.01, width = "90%"),
+                                             sliderInput("input_diff", "Ocean heat diffusivity", min = 0.1, max = 5, value = 2.3, step = 0.1, post = " cm2/s", width = "90%"),
                                              sliderInput("input_ecs", "Equilibrium climate sensitivity", min = 1, max = 6, value = 3, step = 0.1, post = " °C", width = "90%"),
                                              #sliderInput("input_pco2", "Preindustrial CO2 conc. (ppmv CO2)", min = 250, max = 300, value = 276.09, post = " ppmv CO2"), #might remove for v3
                                              sliderInput("input_q10", "Heterotrophic Temperature Sensitivity", min = 1, max = 5, value = 2, step = 0.1, width = "90%"),
-                                             sliderInput("input_volc","Volcanic forcing scaling factor", min = 0, max = 1, value = 1, width = "90%"),
+                                             sliderInput("input_volc","Volcanic forcing scaling factor", min = 0.01, max = 1, value = 1, width = "90%"),
 
                                              # Add hover popups with parameter descriptions
                                              bsPopover("input_aero", "Increasing this means aerosols exert a stronger radiative forcing",


### PR DESCRIPTION
Parameters no longer need the "Load Graphs" button to be clicked to update automatically, and RCPs load correctly instead of being much lower than they should be. Load Graphs button is still there because it's needed to load new output variables

Sliders that must be >0 also adjusted so they can't be set to 0

Closes #54, closes #55